### PR TITLE
Added optional before and after slivers to sandwich the list.

### DIFF
--- a/lib/widget.dart
+++ b/lib/widget.dart
@@ -228,6 +228,12 @@ class InfiniteList extends StatefulWidget {
   /// Proxy property for [ScrollView.physics]
   final ScrollPhysics physics;
 
+  /// Additional slivers to be placed before the list.
+  final List<Widget> sliversBefore;
+
+  /// Additional slivers to be placed after the list.
+  final List<Widget> sliversAfter;
+
   final Key _centerKey;
 
   InfiniteList({
@@ -242,6 +248,8 @@ class InfiniteList extends StatefulWidget {
     this.cacheExtent,
     this.scrollDirection = Axis.vertical,
     this.physics,
+    this.sliversBefore = const [],
+    this.sliversAfter = const [],
   })  : _centerKey =
             (direction == InfiniteListDirection.multi) ? UniqueKey() : null,
         super(key: key);
@@ -277,18 +285,22 @@ class _InfiniteListState extends State<InfiniteList> {
         listItem: widget.builder(context, index),
       );
 
-  List<SliverList> get _slivers {
+  List<Widget> get _slivers {
     switch (widget.direction) {
       case InfiniteListDirection.multi:
         return [
+          ...widget.sliversBefore,
           _reverseList,
           _forwardList,
+          ...widget.sliversAfter,
         ];
 
       case InfiniteListDirection.single:
       default:
         return [
+          ...widget.sliversBefore,
           _forwardList,
+          ...widget.sliversAfter,
         ];
     }
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ repository: https://github.com/TatsuUkraine/flutter_sticky_infinite_list
 issue_tracker: https://github.com/TatsuUkraine/flutter_sticky_infinite_list/issues
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: ">=2.2.2 <3.0.0"
   flutter: ">=1.20.0-2.0.pre"
 
 dependencies:


### PR DESCRIPTION
Sometimes you have your own slivers in addition to the list, e.g. a `SliverPersistentHeader` on top and `SliverToBoxAdapter` at the bottom. These 2 properties allow you to do that.

Dart version bumped to 2.2.2 to make use of the spread operator.